### PR TITLE
Fix error when resolving "adafruit-circuitpython-requests"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     author_email="circuitpython@adafruit.com",
     install_requires=[
         "Adafruit-Blinka",
-        "adafruit-requests",
+        "adafruit-circuitpython-requests",
     ],
     # Choose your license
     license="MIT",


### PR DESCRIPTION
Resolves https://github.com/adafruit/Adafruit_CircuitPython_OAuth2/issues/2 by using correct library name in setup.py. Requirements.txt contains the correct name as well.

@hugodahl